### PR TITLE
feat(database): create initial schema for magic_academy 

### DIFF
--- a/database/db.sql
+++ b/database/db.sql
@@ -1,0 +1,25 @@
+USE magic_academy;
+-- -*********************-
+CREATE TABLE IF NOT EXISTS user_roles (
+    id INT NOT NULL AUTO_INCREMENT,
+    name VARCHAR(20) NOT NULL,
+    PRIMARY KEY (id)
+) ENGINE = INNODB;
+INSERT INTO user_roles (name)
+VALUES ("admin"),
+    ("student"),
+    ("instructor");
+-- -*********************-
+CREATE TABLE IF NOT EXISTS users (
+    id INT NOT NULL AUTO_INCREMENT,
+    name VARCHAR(100) NOT NULL,
+    email VARCHAR(100) NOT NULL,
+    password VARCHAR(20) NOT NULL,
+    /*avatar_url TEXT DEFAULT("https://upload.wikimedia.org/wikipedia/commons/7/7c/Profile_avatar_placeholder_large.png?20150327203541"),*/
+    user_roles_id INT NOT NULL,
+    PRIMARY KEY (id),
+    FOREIGN KEY (user_roles_id) REFERENCES user_roles(id)
+) ENGINE = INNODB;
+INSERT INTO users (name, email, password, user_roles_id)
+VALUES ("Daniel", "dagutmu667@gmail.com", "Dan1245", 1);
+-- -*********************-

--- a/database/db.sql
+++ b/database/db.sql
@@ -1,4 +1,4 @@
--- Date: 2021-09-29, Database creation
+-- Date: 2024-05-24, Database creation
 CREATE DATABASE IF NOT EXISTS magic_academy;
 USE magic_academy;
 

--- a/database/db.sql
+++ b/database/db.sql
@@ -1,17 +1,19 @@
+-- Date: 2021-09-29, Database creation
 CREATE DATABASE IF NOT EXISTS magic_academy;
 USE magic_academy;
--- -*********************-
+
 -- user_roles
 CREATE TABLE IF NOT EXISTS user_roles (
     id INT NOT NULL AUTO_INCREMENT,
     name VARCHAR(20) NOT NULL,
     PRIMARY KEY(id)
 ) ENGINE = InnoDB;
+
 INSERT INTO user_roles(name)
 VALUES ("admin"),
     ("student"),
     ("instructor");
--- -*********************-
+
 -- users
 CREATE TABLE IF NOT EXISTS users (
     id INT NOT NULL AUTO_INCREMENT,
@@ -23,70 +25,117 @@ CREATE TABLE IF NOT EXISTS users (
     PRIMARY KEY(id),
     CONSTRAINT fk_user_roles FOREIGN KEY (user_roles_id) REFERENCES user_roles(id)
 ) ENGINE = InnoDB;
+
 INSERT INTO users(name, email, password, user_roles_id)
 VALUES ("Daniel", "dagutmu667@gmail.com", "Dan1245", 1);
--- -*********************-
+
 -- topics
 CREATE TABLE IF NOT EXISTS topics (
     id INT NOT NULL AUTO_INCREMENT,
     name VARCHAR(50) NOT NULL UNIQUE,
     PRIMARY KEY(id)
 ) ENGINE = InnoDB;
--- -*********************-
+
 -- user_topics
 CREATE TABLE IF NOT EXISTS user_topics (
     id INT NOT NULL AUTO_INCREMENT,
-    users_id_ INT NOT NULL,
+    users_id INT NOT NULL,
     topics_id INT NOT NULL,
-    CONSTRAINT fk_users FOREIGN KEY (users_id) REFERENCES users(id),
-    CONSTRAINT fk_topics FOREIGN KEY (topics_id) REFERENCES topics(id)
+    PRIMARY KEY(id),
+    CONSTRAINT fk_user_topics_users FOREIGN KEY (users_id) REFERENCES users(id),
+    CONSTRAINT fk_user_topics_topics FOREIGN KEY (topics_id) REFERENCES topics(id)
 ) ENGINE = InnoDB;
--- -*********************-
+
 -- courses 
 CREATE TABLE IF NOT EXISTS courses (
     id INT NOT NULL AUTO_INCREMENT,
     name VARCHAR(100) NOT NULL,
     description VARCHAR(255) NOT NULL,
-    thumbnail_url VARCHAR(255) DEFAULT "https://ralfvanveen.com/wp-content/uploads/2021/06/Placeholder-_-Begrippenlijst.svg" users_id INT NOT NULL,
+    thumbnail_url VARCHAR(255) DEFAULT "https://ralfvanveen.com/wp-content/uploads/2021/06/Placeholder-_-Begrippenlijst.svg",
     users_id INT NOT NULL,
     topics_id INT NOT NULL,
     PRIMARY KEY(id),
-    CONSTRAINT fk_users FOREIGN KEY (users_id) REFERENCES users(id),
-    CONSTRAINT fk_topics FOREIGN KEY (topics_id) REFERENCES topics(id)
+    CONSTRAINT fk_courses_users FOREIGN KEY (users_id) REFERENCES users(id),
+    CONSTRAINT fk_courses_topics FOREIGN KEY (topics_id) REFERENCES topics(id)
 ) ENGINE = InnoDB;
--- -*********************-
+
+
 -- course_sections
 CREATE TABLE IF NOT EXISTS course_sections (
     id INT NOT NULL AUTO_INCREMENT,
     name VARCHAR(50) NOT NULL DEFAULT "Untitled section",
     courses_id INT NOT NULL,
-    PRIMARY KEY(id)
-    CONSTRAINT fk_courses FOREIGN KEY (courses_id) REFERENCES courses(id)
-)
--- -*********************-
+    PRIMARY KEY(id),
+    CONSTRAINT fk_course_sections_courses FOREIGN KEY (courses_id) REFERENCES courses(id)
+) ENGINE = InnoDB;
+
 -- section_classes
 CREATE TABLE IF NOT EXISTS section_classes (
     id INT NOT NULL AUTO_INCREMENT,
     title VARCHAR(255),
-    class_type_name VARCHAR(20) CHECK ()
+    class_type_name VARCHAR(20),
     content TEXT,
-    PRIMARY KEY(id)
-)
--- -*********************-
+    duration INT,  -- para videos
+    url VARCHAR(255),  -- para videos
+    course_sections_id INT NOT NULL,
+    PRIMARY KEY(id),
+    CONSTRAINT fk_section_classes_course_sections FOREIGN KEY (course_sections_id) REFERENCES course_sections(id)
+) ENGINE = InnoDB;
+
 -- comments
 CREATE TABLE IF NOT EXISTS comments (
     id INT NOT NULL AUTO_INCREMENT,
     title VARCHAR(255),
     content TEXT NOT NULL,
-    date TIMESTAMP NOT NULL,
-    comment_type_name VARCHAR(7) NOT NULL CHECK ('course', 'section', 'class'),
+    date TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    comment_type_name VARCHAR(7) NOT NULL CHECK (comment_type_name IN ('course', 'section', 'class')),
     comment_types_id INT NOT NULL,
     comment_id INT,
     users_id INT NOT NULL,
     PRIMARY KEY(id),
-    CONSTRAINT fk_users FOREIGN KEY (users_id) REFERENCES users(id)
+    CONSTRAINT fk_comments_users FOREIGN KEY (users_id) REFERENCES users(id),
     CONSTRAINT self_fk_comment FOREIGN KEY (comment_id) REFERENCES comments(id)
-    
 ) ENGINE = InnoDB;
--- -*********************-
---
+
+-- states
+CREATE TABLE IF NOT EXISTS states (
+    id INT NOT NULL AUTO_INCREMENT,
+    name VARCHAR(20) NOT NULL,
+    PRIMARY KEY(id)
+) ENGINE = InnoDB;
+
+-- user_courses
+CREATE TABLE IF NOT EXISTS user_courses (
+    id INT NOT NULL AUTO_INCREMENT,
+    states_id INT NOT NULL,
+    users_id INT NOT NULL,
+    courses_id INT NOT NULL,
+    PRIMARY KEY(id),
+    CONSTRAINT fk_user_courses_states FOREIGN KEY (states_id) REFERENCES states(id),
+    CONSTRAINT fk_user_courses_users FOREIGN KEY (users_id) REFERENCES users(id),
+    CONSTRAINT fk_user_courses_courses FOREIGN KEY (courses_id) REFERENCES courses(id)
+) ENGINE = InnoDB;
+
+-- user_sections
+CREATE TABLE IF NOT EXISTS user_sections (
+    id INT NOT NULL AUTO_INCREMENT,
+    states_id INT NOT NULL,
+    users_id INT NOT NULL,
+    course_sections_id INT NOT NULL,
+    PRIMARY KEY(id),
+    CONSTRAINT fk_user_sections_states FOREIGN KEY (states_id) REFERENCES states(id),
+    CONSTRAINT fk_user_sections_users FOREIGN KEY (users_id) REFERENCES users(id),
+    CONSTRAINT fk_user_sections_course_sections FOREIGN KEY (course_sections_id) REFERENCES course_sections(id)
+) ENGINE = InnoDB;
+
+-- user_classes
+CREATE TABLE IF NOT EXISTS user_classes (
+    id INT NOT NULL AUTO_INCREMENT,
+    states_id INT NOT NULL,
+    users_id INT NOT NULL,
+    section_classes_id INT NOT NULL,
+    PRIMARY KEY(id),
+    CONSTRAINT fk_user_classes_states FOREIGN KEY (states_id) REFERENCES states(id),
+    CONSTRAINT fk_user_classes_users FOREIGN KEY (users_id) REFERENCES users(id),
+    CONSTRAINT fk_user_classes_section_classes FOREIGN KEY (section_classes_id) REFERENCES section_classes(id)
+) ENGINE = InnoDB;

--- a/database/db.sql
+++ b/database/db.sql
@@ -1,25 +1,49 @@
+CREATE DATABASE IF NOT EXISTS magic_academy;
 USE magic_academy;
 -- -*********************-
+-- user_roles
 CREATE TABLE IF NOT EXISTS user_roles (
     id INT NOT NULL AUTO_INCREMENT,
     name VARCHAR(20) NOT NULL,
-    PRIMARY KEY (id)
-) ENGINE = INNODB;
-INSERT INTO user_roles (name)
+    PRIMARY KEY(id)
+) ENGINE = InnoDB;
+INSERT INTO user_roles(name)
 VALUES ("admin"),
     ("student"),
     ("instructor");
 -- -*********************-
+-- users
 CREATE TABLE IF NOT EXISTS users (
     id INT NOT NULL AUTO_INCREMENT,
     name VARCHAR(100) NOT NULL,
-    email VARCHAR(100) NOT NULL,
+    email VARCHAR(100) NOT NULL UNIQUE,
     password VARCHAR(20) NOT NULL,
-    /*avatar_url TEXT DEFAULT("https://upload.wikimedia.org/wikipedia/commons/7/7c/Profile_avatar_placeholder_large.png?20150327203541"),*/
+    avatar_url VARCHAR(255) DEFAULT "https://upload.wikimedia.org/wikipedia/commons/7/7c/Profile_avatar_placeholder_large.png?20150327203541",
     user_roles_id INT NOT NULL,
-    PRIMARY KEY (id),
-    FOREIGN KEY (user_roles_id) REFERENCES user_roles(id)
-) ENGINE = INNODB;
-INSERT INTO users (name, email, password, user_roles_id)
+    PRIMARY KEY(id),
+    CONSTRAINT fk_user_roles FOREIGN KEY (user_roles_id) REFERENCES user_roles(id)
+) ENGINE = InnoDB;
+INSERT INTO users(name, email, password, user_roles_id)
 VALUES ("Daniel", "dagutmu667@gmail.com", "Dan1245", 1);
 -- -*********************-
+-- topics
+CREATE TABLE IF NOT EXISTS topics (
+    id INT NOT NULL AUTO_INCREMENT,
+    name VARCHAR(50) NOT NULL UNIQUE,
+    PRIMARY KEY(id)
+) ENGINE = InnoDB;
+-- -*********************-
+-- user_topics
+-- -*********************-
+-- courses 
+CREATE TABLE IF NOT EXISTS courses (
+    id INT NOT NULL AUTO_INCREMENT,
+    name VARCHAR(100) NOT NULL,
+    description VARCHAR(255) NOT NULL,
+    thumbnail_url VARCHAR(255) DEFAULT "https://ralfvanveen.com/wp-content/uploads/2021/06/Placeholder-_-Begrippenlijst.svg" users_id INT NOT NULL,
+    users_id INT NOT NULL,
+    topics_id INT NOT NULL,
+    PRIMARY KEY(id),
+    CONSTRAINT fk_users FOREIGN KEY (users_id) REFERENCES users(id),
+    CONSTRAINT fk_topics FOREIGN KEY (topics_id) REFERENCES topics(id)
+) ENGINE = InnoDB;

--- a/database/db.sql
+++ b/database/db.sql
@@ -34,6 +34,13 @@ CREATE TABLE IF NOT EXISTS topics (
 ) ENGINE = InnoDB;
 -- -*********************-
 -- user_topics
+CREATE TABLE IF NOT EXISTS user_topics (
+    id INT NOT NULL AUTO_INCREMENT,
+    users_id_ INT NOT NULL,
+    topics_id INT NOT NULL,
+    CONSTRAINT fk_users FOREIGN KEY (users_id) REFERENCES users(id),
+    CONSTRAINT fk_topics FOREIGN KEY (topics_id) REFERENCES topics(id)
+) ENGINE = InnoDB;
 -- -*********************-
 -- courses 
 CREATE TABLE IF NOT EXISTS courses (
@@ -47,3 +54,39 @@ CREATE TABLE IF NOT EXISTS courses (
     CONSTRAINT fk_users FOREIGN KEY (users_id) REFERENCES users(id),
     CONSTRAINT fk_topics FOREIGN KEY (topics_id) REFERENCES topics(id)
 ) ENGINE = InnoDB;
+-- -*********************-
+-- course_sections
+CREATE TABLE IF NOT EXISTS course_sections (
+    id INT NOT NULL AUTO_INCREMENT,
+    name VARCHAR(50) NOT NULL DEFAULT "Untitled section",
+    courses_id INT NOT NULL,
+    PRIMARY KEY(id)
+    CONSTRAINT fk_courses FOREIGN KEY (courses_id) REFERENCES courses(id)
+)
+-- -*********************-
+-- section_classes
+CREATE TABLE IF NOT EXISTS section_classes (
+    id INT NOT NULL AUTO_INCREMENT,
+    title VARCHAR(255),
+    class_type_name VARCHAR(20) CHECK ()
+    content TEXT,
+    PRIMARY KEY(id)
+)
+-- -*********************-
+-- comments
+CREATE TABLE IF NOT EXISTS comments (
+    id INT NOT NULL AUTO_INCREMENT,
+    title VARCHAR(255),
+    content TEXT NOT NULL,
+    date TIMESTAMP NOT NULL,
+    comment_type_name VARCHAR(7) NOT NULL CHECK ('course', 'section', 'class'),
+    comment_types_id INT NOT NULL,
+    comment_id INT,
+    users_id INT NOT NULL,
+    PRIMARY KEY(id),
+    CONSTRAINT fk_users FOREIGN KEY (users_id) REFERENCES users(id)
+    CONSTRAINT self_fk_comment FOREIGN KEY (comment_id) REFERENCES comments(id)
+    
+) ENGINE = InnoDB;
+-- -*********************-
+--


### PR DESCRIPTION
Added initial database schema for the magic_academy project. This includes the following tables and relationships:

- user_roles: Defines roles such as admin, student, and instructor.
- users: Stores user information with a foreign key to user_roles.
- topics: Contains unique topics.
- user_topics: Links users to their topics with foreign keys to users and topics.
- courses: Represents courses with foreign keys to users and topics.
- course_sections: Divides courses into sections.
- section_classes: Includes details of classes within sections.
- comments: Enables comments on courses, sections, and classes, with self-referencing for nested comments.
- states: Defines states for tracking progress.
- user_courses, user_sections, user_classes: Track user progress through courses, sections, and classes with foreign keys to states.

BREAKING CHANGE: This commit sets up the initial schema, which may require existing databases to be reset.